### PR TITLE
make `MemoryNode.matches` copy-on-write

### DIFF
--- a/src/pararules.nim
+++ b/src/pararules.nim
@@ -1,4 +1,4 @@
-import pararules/engine, tables, sets, macros, strutils
+import pararules/[cows, engine], tables, sets, macros, strutils
 
 const
   initPrefix = "init"
@@ -981,4 +981,4 @@ export engine.Session, engine.fireRules, engine.add, engine.queryAll, engine.get
 
 # i need to do this so users don't need to `import sets` explicitly
 # see: https://github.com/nim-lang/Nim/issues/11167
-export sets.items, sets.len
+export sets.items, sets.len, cows

--- a/src/pararules/cows.nim
+++ b/src/pararules/cows.nim
@@ -1,0 +1,57 @@
+import std/tables
+
+type
+  CowTablePayload[K, V] = ref object
+    counter: int
+    data: Table[K, V]
+
+  CowTable*[K, V] = object
+    p: CowTablePayload[K, V]
+
+proc `=destroy`*[K, V](x: var CowTable[K, V]) =
+  if x.p != nil:
+    if x.p.counter == 0:
+      `=destroy`(x.p)
+    else:
+      x.p.counter.dec
+
+proc `=copy`*[K, V](a: var CowTable[K, V], b: CowTable[K, V]) =
+  b.p.counter.inc
+  `=destroy`(a)
+  a.p = b.p
+
+proc deepCopy*[K, V](y: CowTable[K, V]): CowTable[K, V] =
+  result.p = CowTablePayload[K, V](
+    counter: 0,
+    data: y.p.data
+  )
+
+proc initCowTable*[K, V](): CowTable[K, V] =
+  result.p = CowTablePayload[K, V](
+    counter: 0,
+    data: initTable[K, V]()
+  )
+
+proc hasKey*[K, V](t: CowTable[K, V], key: K): bool =
+  t.p.data.hasKey(key)
+
+proc `[]`*[K, V](t: CowTable[K, V], key: K): V =
+  t.p.data[key]
+
+proc `[]=`*[K, V](t: var CowTable[K, V], key: K, val: V) =
+  if t.p.counter > 0:
+    t = t.deepCopy
+  t.p.data[key] = val
+
+proc del*[K, V](t: var CowTable[K, V], key: K) =
+  if t.p.counter > 0:
+    t = t.deepCopy
+  t.p.data.del(key)
+
+iterator pairs*[K, V](t: CowTable[K, V]): (K, V) =
+  for x in t.p.data.pairs:
+    yield x
+
+iterator values*[K, V](t: CowTable[K, V]): V =
+  for x in t.p.data.values:
+    yield x


### PR DESCRIPTION
That makes defensive `nodeToMatches` copying cheaper, and improves `fireRules` performance for a range of scenarios.

Beware, it most likely slightly degrades the performance of inserting facts.  However, it might be an acceptable trade-off as in absolute numbers the win is significant when `fireRules` is called inside the game loop, unless you insert millions of facts each iteration.